### PR TITLE
style: ls-remote 倒序显示

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -105,7 +105,7 @@ func inuse(goroot string) (version string) {
 func render(curV string, items []*semver.Version, out io.Writer) {
 	sort.Sort(semver.Collection(items))
 
-	for i := range items {
+	for i:=len(items)-1;i>=0;i-- {
 		fields := strings.SplitN(items[i].String(), "-", 2)
 		v := strings.TrimSuffix(strings.TrimSuffix(fields[0], ".0"), ".0")
 		if len(fields) > 1 {

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -47,7 +47,7 @@ func Test_render(t *testing.T) {
 		items := []*semver.Version{v0, v1, v2, v3}
 
 		render("1.8.1", items, &buf)
-		So(buf.String(), ShouldEqual, "  1.7\n* 1.8.1\n  1.11.11\n  1.13beta1\n")
+		So(buf.String(), ShouldEqual, "  1.13beta1\n  1.11.11\n* 1.8.1\n  1.7\n")
 	})
 }
 


### PR DESCRIPTION
style: ls-remote 倒序显示
理由：用这个工具大部分是想用新版本吧，倒序显示版本。