### PR TITLE
安装脚本优化

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ go version go1.14.6 darwin/amd64
 $ g uninstall 1.14.7
 Uninstalled go1.14.7
 ```
+
+## 环境变量
+|  name   | default  | description|
+|  ----  | ----  | ---- |
+| G_HOME  | /usr/local/g |  g 安装位置 自动安转脚本运行前设置会使用此安转位置   |
+| G_MIRROR  |  |   Golang Downloads Mirrors  自动安转脚本运行前设置会使用此镜像地址下载 go  |
+
 ## FAQ
 - 环境变量`G_MIRROR`有什么作用？
 


### PR DESCRIPTION
运行脚本前设置 G_HOME 可以自定义安装位置
运行脚本前设置 G_MIRROR 可以自定义镜像地址
脚本相关环境变量独立到了 g/g_profile

.g 目录无法被 mac goland 找到，故将~/g 设置为默认目录，同其它相关项 全部移到这个目录
#18 #47