### PR TITLE
添加 s390x 架构支持

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ build-linux-arm:
 	GOOS=linux GOARCH=arm $(GO) build $(GO_FLAGS) -o bin/linux-arm/g
 build-linux-arm64:
 	GOOS=linux GOARCH=arm64 $(GO) build $(GO_FLAGS) -o bin/linux-arm64/g
+build-linux-s390x:
+        GOOS=linux GOARCH=s390x $(GO) build $(GO_FLAGS) -o  bin/linux-s390x/g
 
 
 build-darwin: build-darwin-amd64 build-darwin-arm64

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install: build
 
 build-all: build-linux build-darwin build-windows
 
-build-linux: build-linux-386 build-linux-amd64 build-linux-arm build-linux-arm64
+build-linux: build-linux-386 build-linux-amd64 build-linux-arm build-linux-arm64 build-linux-s390x
 build-linux-386:
 	GOOS=linux GOARCH=386 $(GO) build $(GO_FLAGS) -o bin/linux-386/g
 build-linux-amd64:

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ build-linux-arm:
 build-linux-arm64:
 	GOOS=linux GOARCH=arm64 $(GO) build $(GO_FLAGS) -o bin/linux-arm64/g
 build-linux-s390x:
-        GOOS=linux GOARCH=s390x $(GO) build $(GO_FLAGS) -o  bin/linux-s390x/g
+    GOOS=linux GOARCH=s390x $(GO) build $(GO_FLAGS) -o  bin/linux-s390x/g
 
 
 build-darwin: build-darwin-amd64 build-darwin-arm64
@@ -56,4 +56,4 @@ clean:
 	rm -f sha256sum.txt
 	rm -rf bin
 
-.PHONY: all build install test package clean build-linux build-darwin build-windows build-linux-386 build-linux-amd64 build-linux-arm build-linux-arm64 build-darwin-amd64 build-darwin-arm64 build-windows-386 build-windows-amd64 build-windows-arm build-windows-arm64
+.PHONY: all build install test package clean build-linux build-darwin build-windows build-linux-386 build-linux-amd64 build-linux-arm build-linux-arm64 build-linux-s390x build-darwin-amd64 build-darwin-arm64 build-windows-386 build-windows-amd64 build-windows-arm build-windows-arm64

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,9 @@ function get_arch() {
     "armv6l" | "armv7l")
         echo "arm"
 	;;
+    "s390x")
+        echo "s390x"
+        ;;
     *)
         echo ${NIL}
         ;;

--- a/package.sh
+++ b/package.sh
@@ -13,6 +13,12 @@ function get_arch() {
     "aarch64" | "arm64")
         echo "arm64"
         ;;
+    "armv6l" | "armv7l")
+        echo "arm"
+        ;;
+    "s390x")
+        echo "s390x"
+        ;;
     *)
         echo ${NIL}
         ;;
@@ -50,7 +56,7 @@ main() {
 
     local release="1.3.0"
 
-    for item in "darwin_amd64" "darwin_arm64" "linux_386" "linux_amd64" "linux_arm" "linux_arm64" "windows_386" "windows_amd64" "windows_arm" "windows_arm64"; do
+    for item in "darwin_amd64" "darwin_arm64" "linux_386" "linux_amd64" "linux_arm" "linux_arm64" "linux_s390x" "windows_386" "windows_amd64" "windows_arm" "windows_arm64"; do
         package ${release} ${item}
     done
 


### PR DESCRIPTION
已在 IBM Linux One 上测试成功。（使用 golang 1.18.1 编译）
```bash
linux1@libecho:~/g$ file g
g: ELF 64-bit MSB executable, IBM S/390, version 1 (SYSV), statically linked, Go BuildID=M3aGKWvULFG5Dgna1rSk/l9uxqHda7rydX044rSOl/BPnzDXJQ2omUOw8-ASsc/6hL0ge_ffB1kgvteH0Ch, not stripped
```