### PR TITLE
Add Only install without using parameters

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -30,6 +30,13 @@ var (
 			Usage:     "Download and install a version",
 			UsageText: "g install <version>",
 			Action:    install,
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:    "nouse",
+					Aliases: []string{"n"},
+					Usage:   "Only install without using",
+				},
+			},
 		},
 		{
 			Name:      "uninstall",

--- a/cli/install.go
+++ b/cli/install.go
@@ -136,6 +136,11 @@ func install(ctx *cli.Context) (err error) {
 	if err = os.Rename(filepath.Join(versionsDir, "go"), targetV); err != nil {
 		return cli.Exit(errstring(err), 1)
 	}
+
+	if ctx.Bool("nouse") {
+		return nil
+	}
+
 	// 重新建立软链接
 	_ = os.Remove(goroot)
 


### PR DESCRIPTION
Sometimes I just need to install a certain version without immediately switching to it

For example, when multiple goland are opened, the default directory is used. At this time, if the version is switched, goland will immediately rebuild the index for all projects.