### PR TITLE
feat: Add support for linux/riscv64,in build and installation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,4 +101,4 @@ upgrade-deps:
 mcp-inspector: build
 	npx @modelcontextprotocol/inspector ./bin/g mcp
 
-.PHONY: all build install install-tools lint test test-coverage view-coverage addlicense package clean upgrade-deps mcp-inspector build-linux build-darwin build-windows build-linux-386 build-linux-amd64 build-linux-arm build-linux-arm64 build-linux-s390x build-darwin-amd64 build-darwin-arm64 build-windows-386 build-windows-amd64 build-windows-arm build-windows-arm64
+.PHONY: all build install install-tools lint test test-coverage view-coverage addlicense package clean upgrade-deps mcp-inspector build-linux build-darwin build-windows build-linux-386 build-linux-amd64 build-linux-arm build-linux-arm64 build-linux-s390x build-linux-riscv64 build-darwin-amd64 build-darwin-arm64 build-windows-386 build-windows-amd64 build-windows-arm build-windows-arm64

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ install: build
 
 build-all: build-linux build-darwin build-windows
 
-build-linux: build-linux-386 build-linux-amd64 build-linux-arm build-linux-arm64 build-linux-s390x
+build-linux: build-linux-386 build-linux-amd64 build-linux-arm build-linux-arm64 build-linux-s390x build-linux-riscv64
 build-linux-386:
 	GOOS=linux GOARCH=386 $(GO) build $(GO_FLAGS) -o bin/linux-386/g
 build-linux-amd64:
@@ -27,6 +27,8 @@ build-linux-arm64:
 	GOOS=linux GOARCH=arm64 $(GO) build $(GO_FLAGS) -o bin/linux-arm64/g
 build-linux-s390x:
 	GOOS=linux GOARCH=s390x $(GO) build $(GO_FLAGS) -o  bin/linux-s390x/g
+build-linux-riscv64:
+	GOOS=linux GOARCH=riscv64 $(GO) build $(GO_FLAGS) -o  bin/linux-riscv64/g
 
 
 build-darwin: build-darwin-amd64 build-darwin-arm64

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,9 @@ function get_arch() {
     "s390x")
         echo "s390x"
         ;;
+    "riscv64")
+        echo "riscv64"
+        ;;
     *)
         echo ${NIL}
         ;;

--- a/package.sh
+++ b/package.sh
@@ -19,6 +19,9 @@ function get_arch() {
     "s390x")
         echo "s390x"
         ;;
+    "riscv64")
+        echo "riscv64"
+        ;;
     *)
         echo ${NIL}
         ;;
@@ -56,7 +59,7 @@ main() {
 
     local release="1.8.0"
 
-    for item in "darwin_amd64" "darwin_arm64" "linux_386" "linux_amd64" "linux_arm" "linux_arm64" "linux_s390x" "windows_386" "windows_amd64" "windows_arm" "windows_arm64"; do
+    for item in "darwin_amd64" "darwin_arm64" "linux_386" "linux_amd64" "linux_arm" "linux_arm64" "linux_s390x" "linux_riscv64" "windows_386" "windows_amd64" "windows_arm" "windows_arm64"; do
         package ${release} ${item}
     done
 


### PR DESCRIPTION
## Summary

This pull request adds full support for the `linux/riscv64` architecture, enabling users on RISC-V platforms to build and install `g` seamlessly.

## Changes Made

1.  **`Makefile`**:
    * A `build-linux-riscv64` target has been added to cross-compile for the RISC-V 64-bit architecture.
    * This new target has been added as a dependency to the `build-linux` meta-target, integrating it into the `make build-all` release process.

2.  **`install.sh`**:
    * The `get_arch()` function has been updated to correctly identify the `riscv64` architecture by checking the output of `uname -m`. This allows the automated installation script to download the correct pre-compiled binary for RISC-V users.

## Test

To ensure the validity of these changes, I have performed end-to-end testing on my RISC-V development board.

- **Hardware**:LicheePi4A 8+64G
- **OS**: RevyOS 20250420

**Test Scenarios:**

**Manual Deployment Test**:
    - **Action**: Cross-compiled the `g` binary using the modified `Makefile`,use `make build-linux-riscv64`.
    - **Result**: The binary was successfully transferred to the RISC-V borad and ran correctly after manual configuration. The `g install 1.24.2` command executed without errors.

```bash
debian@revyos-lpi4a:~$ g install 1.24.2
Downloading 100% [===============] (76/76 MB, 6.6 MB/s)
Computing checksum with SHA256
Checksums matched
Now using go1.24.2 linux/riscv64
```




