### PR TITLE
feat: Add support for custom goroot folder

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -21,7 +21,7 @@ var (
 	ghomeDir     string
 	downloadsDir string
 	versionsDir  string
-	goroot       string
+	gorootDir       string
 )
 
 // Run executes the g command line interface.
@@ -37,7 +37,7 @@ func Run() {
 
 	app.Before = func(ctx *cli.Context) (err error) {
 		ghomeDir = ghome()
-		goroot = filepath.Join(ghomeDir, "go")
+		gorootDir = goroot(ghomeDir)
 		downloadsDir = filepath.Join(ghomeDir, "downloads")
 		if err = os.MkdirAll(downloadsDir, 0750); err != nil {
 			return err
@@ -87,6 +87,7 @@ const (
 	experimentalEnv = "G_EXPERIMENTAL"
 	homeEnv         = "G_HOME"
 	mirrorEnv       = "G_MIRROR"
+	gorootEnv		= "GOROOT"
 )
 
 const (
@@ -105,9 +106,19 @@ func ghome() (dir string) {
 	return filepath.Join(homeDir, ".g")
 }
 
+// goroot returns the goroot directory of go installations.
+func goroot(ghomeDir string) (dir string) {
+	if experimental := os.Getenv(experimentalEnv); strings.EqualFold(experimental, "true") {
+		if dir = os.Getenv(gorootEnv); dir != "" {
+			return dir
+		}
+	}
+	return filepath.Join(ghomeDir, "go")
+}
+
 // inuse detects currently active Go version.
-func inuse(goroot string) (version string) {
-	p, _ := os.Readlink(goroot)
+func inuse(gorootDir string) (version string) {
+	p, _ := os.Readlink(gorootDir)
 	return filepath.Base(p)
 }
 
@@ -118,7 +129,7 @@ func installed() (versions map[string]bool) {
 		return
 	}
 
-	inused := inuse(goroot)
+	inused := inuse(gorootDir)
 	versions = make(map[string]bool, 0)
 	for _, d := range dirs {
 		if !d.IsDir() {

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -45,7 +45,7 @@ func Test_ghome(t *testing.T) {
 func Test_inuse(t *testing.T) {
 	t.Run("查询当前使用中的go版本", func(t *testing.T) {
 		rootDir := filepath.Join(os.TempDir(), fmt.Sprintf(".g_%d", time.Now().Unix()))
-		goroot = filepath.Join(rootDir, "go")
+		gorootDir = filepath.Join(rootDir, "go")
 		versionsDir = filepath.Join(rootDir, "versions")
 		vDir := filepath.Join(versionsDir, "1.12.6")
 
@@ -53,8 +53,8 @@ func Test_inuse(t *testing.T) {
 		_ = os.MkdirAll(vDir, 0755)
 		defer os.RemoveAll(rootDir)
 
-		assert.Nil(t, mkSymlink(vDir, goroot))
-		assert.Equal(t, "1.12.6", inuse(goroot))
+		assert.Nil(t, mkSymlink(vDir, gorootDir))
+		assert.Equal(t, "1.12.6", inuse(gorootDir))
 	})
 }
 

--- a/cli/install.go
+++ b/cli/install.go
@@ -184,12 +184,12 @@ func switchVersion(vname string) error {
 	targetV := filepath.Join(versionsDir, vname)
 
 	// Recreate symbolic link
-	_ = os.Remove(goroot)
+	_ = os.Remove(gorootDir)
 
-	if err := mkSymlink(targetV, goroot); err != nil {
+	if err := mkSymlink(targetV, gorootDir); err != nil {
 		return errors.WithStack(err)
 	}
-	if output, err := exec.Command(filepath.Join(goroot, "bin", "go"), "version").Output(); err == nil {
+	if output, err := exec.Command(filepath.Join(gorootDir, "bin", "go"), "version").Output(); err == nil {
 		fmt.Printf("Now using %s", strings.TrimPrefix(string(output), "go version "))
 	}
 	return nil


### PR DESCRIPTION
## Summary
### In experimental environment, the GOROOT directory can be set outside the G_HOME directory：

<img width="810" height="524" alt="image" src="https://github.com/user-attachments/assets/77d4b59a-f679-489a-b905-e431995e69e7" />
<img width="801" height="380" alt="image" src="https://github.com/user-attachments/assets/b4e29b0c-84f4-458c-916b-89f6268ee623" />

## Issues
- Refs #135
- Closes #135 
